### PR TITLE
Add CI workflow to check for commonly misspelled words

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,9 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/spell-check/.codespellrc
+# See: https://github.com/codespell-project/codespell#using-a-config-file
+[codespell]
+# In the event of a false positive, add the problematic word, in all lowercase, to a comma-separated list here:
+ignore-words-list = ,
+skip = ./.git,./.licenses,__pycache__,node_modules,./go.mod,./go.sum,./package-lock.json,./poetry.lock,./yarn.lock
+builtin = clear,informal,en-GB_to_en-US
+check-filenames =
+check-hidden =

--- a/.codespellrc
+++ b/.codespellrc
@@ -2,7 +2,7 @@
 # See: https://github.com/codespell-project/codespell#using-a-config-file
 [codespell]
 # In the event of a false positive, add the problematic word, in all lowercase, to a comma-separated list here:
-ignore-words-list = ,
+ignore-words-list = freeed,
 skip = ./.git,./.licenses,__pycache__,node_modules,./go.mod,./go.sum,./package-lock.json,./poetry.lock,./yarn.lock
 builtin = clear,informal,en-GB_to_en-US
 check-filenames =

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -1,0 +1,22 @@
+name: Spell Check
+
+# See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
+on:
+  push:
+  pull_request:
+  schedule:
+    # Run every Tuesday at 8 AM UTC to catch new misspelling detections resulting from dictionary updates.
+    - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  spellcheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Spell check
+        uses: codespell-project/actions-codespell@master

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build
+.idea/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+<img src="https://content.arduino.cc/website/Arduino_logo_teal.svg" height="100" align="right" />
+
+`USBHostMbed5`
+==============
+
+[![Spell Check status](https://github.com/facchinm/USBHostMbed5/actions/workflows/spell-check.yml/badge.svg)](https://github.com/facchinm/USBHostMbed5/actions/workflows/spell-check.yml)
+
+ARM Mbed5 USB Host library ported for [ArduinoCore-mbed](https://github.com/arduino/ArduinoCore-mbed) enabled boards.
+
+## :mag_right: Resources
+
+* [How to install a library](https://www.arduino.cc/en/guide/libraries)
+* [Help Center](https://support.arduino.cc/)
+* [Forum](https://forum.arduino.cc)
+
+## :bug: Bugs & Issues
+
+If you want to report an issue with this library, you can submit it to the [issue tracker](https://github.com/arduino-libraries/Arduino_Braccio_plusplus/issues) of this repository. Remember to include as much detail as you can about your hardware set-up, code and steps for reproducing the issue. Make sure you're using an original Arduino board.
+
+## :technologist: Development
+
+There are many ways to contribute:
+
+* Improve documentation and examples
+* Fix a bug
+* Test open Pull Requests
+* Implement a new feature
+* Discuss potential ways to improve this library
+
+You can submit your patches directly to this repository as Pull Requests. Please provide a detailed description of the problem you're trying to solve and make sure you test on real hardware.
+
+## :yellow_heart: Donations
+
+This open-source code is maintained by Arduino with the help of the community. We invest a considerable amount of time in testing code, optimizing it and introducing new features. Please consider [donating](https://www.arduino.cc/en/donate/) or [sponsoring](https://github.com/sponsors/arduino) to support our work, as well as [buying original Arduino boards](https://store.arduino.cc/) which is the best way to make sure our effort can continue in the long term.
+

--- a/src/USBHost/USBDeviceConnected.h
+++ b/src/USBHost/USBDeviceConnected.h
@@ -52,7 +52,7 @@ public:
     * Attach an USBEndpoint to this device
     *
     * @param intf_nb interface number
-    * @param ep pointeur on the USBEndpoint which will be attached
+    * @param ep pointer on the USBEndpoint which will be attached
     * @returns true if successful, false otherwise
     */
     bool addEndpoint(uint8_t intf_nb, USBEndpoint * ep);

--- a/src/USBHost/USBEndpoint.h
+++ b/src/USBHost/USBEndpoint.h
@@ -107,7 +107,7 @@ public:
     }
 
     /**
-    * Call the handler associted to the end of a transfer
+    * Call the handler associated to the end of a transfer
     */
     inline void call() {
         if (rx)

--- a/src/USBHost/USBHost.h
+++ b/src/USBHost/USBHost.h
@@ -132,7 +132,7 @@ public:
     /**
     * reset a specific device
     *
-    * @param dev device which will be resetted
+    * @param dev device which will be reset
     */
     USB_TYPE resetDevice(USBDeviceConnected * dev);
 

--- a/src/USBHost/USBHostTypes.h
+++ b/src/USBHost/USBHostTypes.h
@@ -188,7 +188,7 @@ typedef struct hcTd {
 typedef struct hcEd {
     __IO  uint32_t  control;        // Endpoint descriptor control
     __IO  HCTD *  tailTD;           // Physical address of tail in Transfer descriptor list
-    __IO  HCTD *  headTD;           // Physcial address of head in Transfer descriptor list
+    __IO  HCTD *  headTD;           // Physical address of head in Transfer descriptor list
     __IO  hcEd *  nextED;         // Physical address of next Endpoint descriptor
 } PACKED HCED;
 // ----------- Host Controller Communication Area ------------

--- a/src/USBHostMSD/USBHostMSD.cpp
+++ b/src/USBHostMSD/USBHostMSD.cpp
@@ -273,7 +273,7 @@ int USBHostMSD::SCSITransfer(uint8_t * cmd, uint8_t cmd_len, int flags, uint8_t 
                                     BO_MASS_STORAGE_RESET,
                                     0, msd_intf, NULL, 0);
 
-        // unstall both endpoints
+        // uninstall both endpoints
         res = host->controlWrite(   dev,
                                     USB_RECIPIENT_ENDPOINT | USB_HOST_TO_DEVICE | USB_REQUEST_TYPE_STANDARD,
                                     CLEAR_FEATURE,

--- a/src/targets/TARGET_STM/USBHALHost_STM.cpp
+++ b/src/targets/TARGET_STM/USBHALHost_STM.cpp
@@ -128,7 +128,7 @@ void HAL_HCD_HC_NotifyURBChange_Callback(HCD_HandleTypeDef *hhcd, uint8_t chnum,
             }
         }
         if ((type == EP_TYPE_INTR)) {
-            /*  reply a packet of length NULL, this will be analyse in call back
+            /*  reply a packet of length NULL, this will be analyze in call back
              *  for mouse or hub */
             td->state = USB_TYPE_IDLE ;
             HAL_HCD_DisableInt(hhcd, chnum);


### PR DESCRIPTION
On every push, pull request, and periodically, use codespell to check for commonly misspelled words.

In the event of a false positive, the problematic word should be added, in all lowercase, to the field of . Regardless of the case of the word in the false positive, it must be in all lowercase in the ignore list. The ignore list is comma-separated with no spaces.