### PR TITLE
Fix error in size()

### DIFF
--- a/src/USBHostMSD/USBHostMSD.cpp
+++ b/src/USBHostMSD/USBHostMSD.cpp
@@ -401,7 +401,7 @@ mbed::bd_size_t USBHostMSD::get_erase_size() const
 mbed::bd_size_t USBHostMSD::size() const
 {
     USB_DBG("FILESYSTEM: size ");
-    return (disk_init ? (mbed::bd_size_t)blockSize : 0);
+    return (disk_init ? (mbed::bd_size_t)blockCount*blockSize : 0);
 }
 
 const char *USBHostMSD::get_type() const


### PR DESCRIPTION
The size() function incorrectly returned the block size instead of the block size times the block count. This sent FATFileSystem::reformat() into an mbed_assert_internal - mbed_error - mbed_halt_system sequence, when disk_get_sector_count() in FATFileSystem.cpp calculates scount as 1 as a consequence. Thus, it wasn't possible to format FAT file systems on USB thumb drives.