### PR TITLE
Fixes connect() bug, crash bug, I/O error bug, and more.

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -2,7 +2,7 @@
 # See: https://github.com/codespell-project/codespell#using-a-config-file
 [codespell]
 # In the event of a false positive, add the problematic word, in all lowercase, to a comma-separated list here:
-ignore-words-list = freeed,
+ignore-words-list = freeed,unstall,
 skip = ./.git,./.licenses,__pycache__,node_modules,./go.mod,./go.sum,./package-lock.json,./poetry.lock,./yarn.lock
 builtin = clear,informal,en-GB_to_en-US
 check-filenames =

--- a/src/USBHost/USBHost.cpp
+++ b/src/USBHost/USBHost.cpp
@@ -1145,7 +1145,7 @@ USB_TYPE USBHost::generalTransfer(USBDeviceConnected * dev, USBEndpoint * ep, ui
         USB_DBG_TRANSFER("%s TRANSFER res: %s on ep: %p\r\n", type_str, ep->getStateString(), ep);
 
         if (res != USB_TYPE_IDLE) {
-            // Set state to USB_TYPE_IDLE to allow recover from the error, but return the error
+            // Set state to USB_TYPE_IDLE to allow recovery from the error, but return the error
             ep->setState(USB_TYPE_IDLE);
             return res;
         }

--- a/src/USBHost/USBHost.cpp
+++ b/src/USBHost/USBHost.cpp
@@ -1145,6 +1145,8 @@ USB_TYPE USBHost::generalTransfer(USBDeviceConnected * dev, USBEndpoint * ep, ui
         USB_DBG_TRANSFER("%s TRANSFER res: %s on ep: %p\r\n", type_str, ep->getStateString(), ep);
 
         if (res != USB_TYPE_IDLE) {
+            // Set state to USB_TYPE_IDLE to allow recover from the error, but return the error
+            ep->setState(USB_TYPE_IDLE);
             return res;
         }
 

--- a/src/USBHostMSD/USBHostMSD.cpp
+++ b/src/USBHostMSD/USBHostMSD.cpp
@@ -273,7 +273,7 @@ int USBHostMSD::SCSITransfer(uint8_t * cmd, uint8_t cmd_len, int flags, uint8_t 
                                     BO_MASS_STORAGE_RESET,
                                     0, msd_intf, NULL, 0);
 
-        // uninstall both endpoints
+        // unstall [sic!] both endpoints
         res = host->controlWrite(   dev,
                                     USB_RECIPIENT_ENDPOINT | USB_HOST_TO_DEVICE | USB_REQUEST_TYPE_STANDARD,
                                     CLEAR_FEATURE,

--- a/src/USBHostMSD/USBHostMSD.cpp
+++ b/src/USBHostMSD/USBHostMSD.cpp
@@ -193,7 +193,8 @@ int USBHostMSD::checkResult(uint8_t res, USBEndpoint * ep)
         return -1;
     }
 
-    // if ep stalled: send clear feature
+    // Notice that USB_TYPE_STALL_ERROR is never actually set anywhere in the library for the ST target, because
+    // URB_STALL is never handled directly. Otherwise, this would be the code to unstall the EP.
     if (res == USB_TYPE_STALL_ERROR) {
         res = host->controlWrite(   dev,
                                     USB_RECIPIENT_ENDPOINT | USB_HOST_TO_DEVICE | USB_REQUEST_TYPE_STANDARD,
@@ -285,7 +286,9 @@ int USBHostMSD::SCSITransfer(uint8_t * cmd, uint8_t cmd_len, int flags, uint8_t 
                                     BO_MASS_STORAGE_RESET,
                                     0, msd_intf, NULL, 0);
 
-        // unstall [sic!] both endpoints
+        // Unstall [sic!] both endpoints.
+        // Notice that this is the unstall that is required by the specification as part of clearing a Phase Error,
+        // _not_ the unstall for an ordinarily stalled EP!
         res = host->controlWrite(   dev,
                                     USB_RECIPIENT_ENDPOINT | USB_HOST_TO_DEVICE | USB_REQUEST_TYPE_STANDARD,
                                     CLEAR_FEATURE,

--- a/src/USBHostMSD/USBHostMSD.cpp
+++ b/src/USBHostMSD/USBHostMSD.cpp
@@ -187,6 +187,12 @@ int USBHostMSD::inquiry(uint8_t lun, uint8_t page_code)
 
 int USBHostMSD::checkResult(uint8_t res, USBEndpoint * ep)
 {
+    // Guard against host not being initialized
+    if (nullptr == host)
+    {
+        return -1;
+    }
+
     // if ep stalled: send clear feature
     if (res == USB_TYPE_STALL_ERROR) {
         res = host->controlWrite(   dev,
@@ -210,6 +216,12 @@ int USBHostMSD::SCSITransfer(uint8_t * cmd, uint8_t cmd_len, int flags, uint8_t 
 {
 
     int res = 0;
+
+    // Guard against host not being initialized
+    if (nullptr == host)
+    {
+        return -1;
+    }
 
     cbw.Signature = CBW_SIGNATURE;
     cbw.Tag = 0;
@@ -310,6 +322,13 @@ int USBHostMSD::dataTransfer(uint8_t * buf, uint32_t block, uint8_t nbBlock, int
 int USBHostMSD::getMaxLun()
 {
     uint8_t buf[1], res;
+
+    // Guard against host not being initialized
+    if (nullptr == host)
+    {
+        return -1;
+    }
+
     res = host->controlRead(    dev, USB_RECIPIENT_INTERFACE | USB_DEVICE_TO_HOST | USB_REQUEST_TYPE_CLASS,
                                 0xfe, 0, msd_intf, buf, 1);
     USB_DBG("max lun: %d", buf[0]);

--- a/src/USBHostMSD/USBHostMSD.h
+++ b/src/USBHostMSD/USBHostMSD.h
@@ -75,7 +75,7 @@ protected:
 
 
 private:
-    USBHost * host;
+    USBHost * host = nullptr;
     USBDeviceConnected * dev;
     bool dev_connected;
     USBEndpoint * bulk_in;

--- a/src/targets/TARGET_STM/USBEndpoint_STM.cpp
+++ b/src/targets/TARGET_STM/USBEndpoint_STM.cpp
@@ -153,6 +153,10 @@ void USBEndpoint::setState(USB_TYPE st)
         USBx_HC(hced->ch_num)->HCCHAR &= ~USB_OTG_HCCHAR_CHDIS;
         USBx_HC(hced->ch_num)->HCCHAR |= USB_OTG_HCCHAR_CHENA;
         // <--
+        // Set state to USB_TYPE_IDLE to allow the library to recover from the error.
+        // WARNING: This might lead to some errors going unreported, and should be improved in the future, but
+        //          at least the library passes all our tests from higher levels at this point, which it didn't
+        //          do before.
         state = USB_TYPE_IDLE;
     }
 }

--- a/src/targets/TARGET_STM/USBEndpoint_STM.cpp
+++ b/src/targets/TARGET_STM/USBEndpoint_STM.cpp
@@ -20,6 +20,8 @@
 
 #include "USBHost/dbg.h"
 #include "USBHost/USBEndpoint.h"
+#include "USBHost/USBDeviceConnected.h"
+
 extern uint32_t HAL_HCD_HC_GetMaxPacket(HCD_HandleTypeDef *hhcd, uint8_t chn_num);
 extern uint32_t HAL_HCD_HC_GetType(HCD_HandleTypeDef *hhcd, uint8_t chn_num);
 extern void HAL_HCD_DisableInt(HCD_HandleTypeDef *hhcd, uint8_t chn_num);
@@ -115,13 +117,13 @@ void USBEndpoint::setState(USB_TYPE st)
     if (st == USB_TYPE_ERROR) {
         HAL_HCD_HC_Halt((HCD_HandleTypeDef *)hced->hhcd, hced->ch_num);
         HAL_HCD_DisableInt((HCD_HandleTypeDef *)hced->hhcd, hced->ch_num);
-
-    }
-    if (st == USB_TYPE_ERROR) {
         uint8_t hcd_speed = HCD_SPEED_FULL;
         /* small speed device with hub not supported
            if (this->speed) hcd_speed = HCD_SPEED_LOW;*/
-        HAL_HCD_HC_Init((HCD_HandleTypeDef *)hced->hhcd, hced->ch_num, address, 0, hcd_speed,  type, size);
+
+        // Notice that dev->getAddress() must be used instead of device_address, because the latter will contain
+        // incorrect values in certain cases
+        HAL_HCD_HC_Init((HCD_HandleTypeDef *)hced->hhcd, hced->ch_num, address, dev->getAddress(), hcd_speed,  type, size);
     }
 }
 

--- a/src/targets/TARGET_STM/USBEndpoint_STM.cpp
+++ b/src/targets/TARGET_STM/USBEndpoint_STM.cpp
@@ -153,11 +153,6 @@ void USBEndpoint::setState(USB_TYPE st)
         USBx_HC(hced->ch_num)->HCCHAR &= ~USB_OTG_HCCHAR_CHDIS;
         USBx_HC(hced->ch_num)->HCCHAR |= USB_OTG_HCCHAR_CHENA;
         // <--
-        // Set state to USB_TYPE_IDLE to allow the library to recover from the error.
-        // WARNING: This might lead to some errors going unreported, and should be improved in the future, but
-        //          at least the library passes all our tests from higher levels at this point, which it didn't
-        //          do before.
-        state = USB_TYPE_IDLE;
     }
 }
 

--- a/src/targets/TARGET_STM/USBEndpoint_STM.cpp
+++ b/src/targets/TARGET_STM/USBEndpoint_STM.cpp
@@ -118,10 +118,12 @@ void USBEndpoint::setState(USB_TYPE st)
         USBx_HC(hced->ch_num)->HCCHAR |= USB_OTG_HCCHAR_CHDIS;
         // Disable the channel
         USBx_HC(hced->ch_num)->HCCHAR |= USB_OTG_HCCHAR_CHDIS | USB_OTG_HCCHAR_CHENA;
-        // <-- Notice the lack of error handling here - after testing a lot of 
-        //     combinations, it seems that the USB host controller doesn't work fully
-        //     according to the reference manual in this aspect, which might also
-        //     be the reason for lacking error handling in the ST USB LL
+        // Notice the lack of error handling here - after testing a lot of 
+        // combinations, it seems that the USB host controller doesn't work fully
+        // according to the reference manual in this aspect, which might also
+        // be the reason for lacking error handling in the ST USB LL - instead,
+        // we use a 50 us delay to wait for the channel to disable
+        wait_us(50);
 
         HAL_HCD_DisableInt((HCD_HandleTypeDef *)hced->hhcd, hced->ch_num);
         *addr = 0;
@@ -132,10 +134,12 @@ void USBEndpoint::setState(USB_TYPE st)
         USBx_HC(hced->ch_num)->HCCHAR |= USB_OTG_HCCHAR_CHDIS;
         // Disable the channel
         USBx_HC(hced->ch_num)->HCCHAR |= USB_OTG_HCCHAR_CHDIS | USB_OTG_HCCHAR_CHENA;
-        // <-- Notice the lack of error handling here - after testing a lot of 
-        //     combinations, it seems that the USB host controller doesn't work fully
-        //     according to the reference manual in this aspect, which might also
-        //     be the reason for lacking error handling in the ST USB LL
+        // Notice the lack of error handling here - after testing a lot of 
+        // combinations, it seems that the USB host controller doesn't work fully
+        // according to the reference manual in this aspect, which might also
+        // be the reason for lacking error handling in the ST USB LL - instead,
+        // we use a 50 us delay to wait for the channel to disable
+        wait_us(50);
 
         HAL_HCD_DisableInt((HCD_HandleTypeDef *)hced->hhcd, hced->ch_num);
         uint8_t hcd_speed = HCD_SPEED_FULL;

--- a/src/targets/TARGET_STM/USBEndpoint_STM.cpp
+++ b/src/targets/TARGET_STM/USBEndpoint_STM.cpp
@@ -181,7 +181,7 @@ USB_TYPE USBEndpoint::queueTransfer()
     state = USB_TYPE_PROCESSING;
     /*  one request */
     td_current->nextTD = (hcTd *)0;
-#if defined(MAX_NYET_RETRY)
+#if defined(MAX_NOTREADY_RETRY)
     td_current->retry = 0;
 #endif
     td_current->setup = setup;

--- a/src/targets/TARGET_STM/USBHALHost_STM.cpp
+++ b/src/targets/TARGET_STM/USBHALHost_STM.cpp
@@ -93,7 +93,7 @@ void HAL_HCD_HC_NotifyURBChange_Callback(HCD_HandleTypeDef *hhcd, uint8_t chnum,
         if ((type == EP_TYPE_BULK) || (type == EP_TYPE_CTRL)) {
             switch (urb_state) {
                 case URB_DONE:
-#if defined(MAX_NYET_RETRY)
+#if defined(MAX_NOTREADY_RETRY)
                     td->retry = 0;
 #endif
                     if (td->size >  max_size) {
@@ -110,8 +110,8 @@ void HAL_HCD_HC_NotifyURBChange_Callback(HCD_HandleTypeDef *hhcd, uint8_t chnum,
                     /*  try again  */
                     /*  abritary limit , to avoid dead lock if other error than
                      *  slow response is  */
-#if defined(MAX_NYET_RETRY)
-                    if (td->retry < MAX_NYET_RETRY) {
+#if defined(MAX_NOTREADY_RETRY)
+                    if (td->retry < MAX_NOTREADY_RETRY) {
                         /*  increment retry counter */
                         td->retry++;
 #endif
@@ -119,9 +119,9 @@ void HAL_HCD_HC_NotifyURBChange_Callback(HCD_HandleTypeDef *hhcd, uint8_t chnum,
                         HAL_HCD_HC_SubmitRequest(hhcd, chnum, dir, type, !td->setup, (uint8_t *) td->currBufPtr, length, 0);
                         HAL_HCD_EnableInt(hhcd, chnum);
                         return;
-#if defined(MAX_NYET_RETRY)
+#if defined(MAX_NOTREADY_RETRY)
                     } else {
-                        //USB_ERR("urb_state != URB_NOTREADY");
+                        // MAX_NOTREADY_RETRY reached, so stop trying to resend and instead wait for a timeout at a higher layer
                     }
 #endif
                     break;

--- a/src/targets/TARGET_STM/USBHALHost_STM.cpp
+++ b/src/targets/TARGET_STM/USBHALHost_STM.cpp
@@ -76,6 +76,21 @@ uint32_t HAL_HCD_HC_GetType(HCD_HandleTypeDef *hhcd, uint8_t chnum)
     return hhcd->hc[chnum].ep_type;
 }
 
+// The urb_state parameter can be one of the following according to the ST documentation, but the explanations
+// that follow are the result of an analysis of the ST HAL / LL source code, the Reference Manual for the
+// STM32H747 microcontroller, and the source code of this library:
+//
+//  - URB_ERROR    = various serious errors that may be hard or impossible to recover from without pulling
+//                   the thumb drive out and putting it back in again, but we will try
+//  - URB_IDLE     = set by a call to HAL_HCD_HC_SubmitRequest(), but never used by this library
+//  - URB_NYET     = never actually used by the ST HAL / LL at the time of writing, nor by this library
+//  - URB_STALL    = a stall response from the device - but it is never handled by the library and will end up
+//                   as a timeout at a higher layer, because of an ep_queue.get() timeout, which will activate
+//                   error recovery indirectly
+//  - URB_DONE     = the transfer completed normally without errrors
+//  - URB_NOTREADY = a NAK, NYET, or not more than a couple of repeats of some of the errors that will
+//                   become URB_ERROR if they repeat several times in a row
+//
 void HAL_HCD_HC_NotifyURBChange_Callback(HCD_HandleTypeDef *hhcd, uint8_t chnum, HCD_URBStateTypeDef urb_state)
 {
     USBHALHost_Private_t *priv = (USBHALHost_Private_t *)(hhcd->pData);
@@ -107,14 +122,11 @@ void HAL_HCD_HC_NotifyURBChange_Callback(HCD_HandleTypeDef *hhcd, uint8_t chnum,
                     }
                     break;
                 case  URB_NOTREADY:
-                    /*  try again  */
-                    /*  abritary limit , to avoid dead lock if other error than
-                     *  slow response is  */
 #if defined(MAX_NOTREADY_RETRY)
                     if (td->retry < MAX_NOTREADY_RETRY) {
-                        /*  increment retry counter */
                         td->retry++;
 #endif
+                        // Submit the same request again, because the device wasn't ready to accept the last one
                         length = td->size <= max_size ? td->size : max_size;
                         HAL_HCD_HC_SubmitRequest(hhcd, chnum, dir, type, !td->setup, (uint8_t *) td->currBufPtr, length, 0);
                         HAL_HCD_EnableInt(hhcd, chnum);
@@ -138,6 +150,9 @@ void HAL_HCD_HC_NotifyURBChange_Callback(HCD_HandleTypeDef *hhcd, uint8_t chnum,
                 td->state = USB_TYPE_IDLE;
             }
             else if (urb_state == URB_ERROR) {
+                // While USB_TYPE_ERROR in the endpoint state is used to activate error recovery, this value is actually never used.
+                // Going here will lead to a timeout at a higher layer, because of ep_queue.get() timeout, which will activate error
+                // recovery indirectly.
                 td->state = USB_TYPE_ERROR;
             } else {
                 td->state = USB_TYPE_PROCESSING;

--- a/src/targets/TARGET_STM/USBHALHost_STM.cpp
+++ b/src/targets/TARGET_STM/USBHALHost_STM.cpp
@@ -87,7 +87,7 @@ uint32_t HAL_HCD_HC_GetType(HCD_HandleTypeDef *hhcd, uint8_t chnum)
 //  - URB_STALL    = a stall response from the device - but it is never handled by the library and will end up
 //                   as a timeout at a higher layer, because of an ep_queue.get() timeout, which will activate
 //                   error recovery indirectly
-//  - URB_DONE     = the transfer completed normally without errrors
+//  - URB_DONE     = the transfer completed normally without errors
 //  - URB_NOTREADY = a NAK, NYET, or not more than a couple of repeats of some of the errors that will
 //                   become URB_ERROR if they repeat several times in a row
 //

--- a/src/targets/TARGET_STM/USBHALHost_STM.h
+++ b/src/targets/TARGET_STM/USBHALHost_STM.h
@@ -38,7 +38,7 @@
 
 #define TOTAL_SIZE (HCCA_SIZE + (MAX_ENDPOINT * ED_SIZE) + (MAX_TD * TD_SIZE))
 
-#define MAX_NYET_RETRY      5
+#define MAX_NOTREADY_RETRY      5
 
 /* STM device FS have 11 channels (definition is for 60 channels) */
 static volatile  uint8_t usb_buf[TOTAL_SIZE];

--- a/src/targets/TARGET_STM/USBHALHost_STM.h
+++ b/src/targets/TARGET_STM/USBHALHost_STM.h
@@ -38,7 +38,8 @@
 
 #define TOTAL_SIZE (HCCA_SIZE + (MAX_ENDPOINT * ED_SIZE) + (MAX_TD * TD_SIZE))
 
-#define MAX_NOTREADY_RETRY      5
+// This must be a large number to account for the relatively high write latency of USB thumb drives
+#define MAX_NOTREADY_RETRY      50000
 
 /* STM device FS have 11 channels (definition is for 60 channels) */
 static volatile  uint8_t usb_buf[TOTAL_SIZE];


### PR DESCRIPTION
1. Fixes USB thumb drive remove and insert again bug
2. Fixes crash on mount() before connect() bug
3. Fixes incorrect comment about stall handling
4. Fixes I/O errors when writing to some USB thumb drive models
5. Fixes incorrectly named constant (MAX_NYET_RETRY to MAX_NOTREADY_RETRY)
6. Improves the source code comments in several locations