### PR TITLE
Fix crash bugs on connect and disconnect

### DIFF
--- a/src/USBHost/USBHost.cpp
+++ b/src/USBHost/USBHost.cpp
@@ -697,11 +697,20 @@ bool USBHost::addEndpoint(USBDeviceConnected * dev, uint8_t intf_nb, USBEndpoint
         default:
             return false;
     }
-
+#else
+    // The code that follows this check shouldn't be executed for a control endpoint
+    if (CONTROL_ENDPOINT == (ep->getType()))
+    {
+        return true;
+    }
 #endif
     ep->dev = dev;
-    dev->addEndpoint(intf_nb, ep);
-
+    // This check might not be necessary when the control endpoint check is added above, but
+    // is included just in case
+    if (nullptr != dev)
+    {
+        dev->addEndpoint(intf_nb, ep);
+    }
     return true;
 }
 

--- a/src/USBHost/USBHost.cpp
+++ b/src/USBHost/USBHost.cpp
@@ -697,16 +697,8 @@ bool USBHost::addEndpoint(USBDeviceConnected * dev, uint8_t intf_nb, USBEndpoint
         default:
             return false;
     }
-#else
-    // The code that follows this check shouldn't be executed for a control endpoint
-    if (CONTROL_ENDPOINT == (ep->getType()))
-    {
-        return true;
-    }
 #endif
     ep->dev = dev;
-    // This check might not be necessary when the control endpoint check is added above, but
-    // is included just in case
     if (nullptr != dev)
     {
         dev->addEndpoint(intf_nb, ep);

--- a/src/targets/TARGET_STM/USBEndpoint_STM.cpp
+++ b/src/targets/TARGET_STM/USBEndpoint_STM.cpp
@@ -146,13 +146,17 @@ void USBEndpoint::setState(USB_TYPE st)
         /* small speed device with hub not supported
            if (this->speed) hcd_speed = HCD_SPEED_LOW;*/
 
-        // Notice that dev->getAddress() must be used instead of device_address, because the latter will contain
-        // incorrect values in certain cases
-        HAL_HCD_HC_Init((HCD_HandleTypeDef *)hced->hhcd, hced->ch_num, address, dev->getAddress(), hcd_speed,  type, size);
-        // HAL_HCD_HC_Init() doesn't fully enable the channel after disable above, so we do it here -->
-        USBx_HC(hced->ch_num)->HCCHAR &= ~USB_OTG_HCCHAR_CHDIS;
-        USBx_HC(hced->ch_num)->HCCHAR |= USB_OTG_HCCHAR_CHENA;
-        // <--
+        // If the device seems to be gone, there is no use trying to enable the channel again
+        if (nullptr != dev)
+        {
+            // Notice that dev->getAddress() must be used instead of device_address, because the latter will contain
+            // incorrect values in certain cases
+            HAL_HCD_HC_Init((HCD_HandleTypeDef *)hced->hhcd, hced->ch_num, address, dev->getAddress(), hcd_speed,  type, size);
+            // HAL_HCD_HC_Init() doesn't fully enable the channel after disable above, so we do it here -->
+            USBx_HC(hced->ch_num)->HCCHAR &= ~USB_OTG_HCCHAR_CHDIS;
+            USBx_HC(hced->ch_num)->HCCHAR |= USB_OTG_HCCHAR_CHENA;
+            // <--
+        }
     }
 }
 


### PR DESCRIPTION
Code that would return early for the control endpoint had been removed in the
ST port by Arm, which led to a null pointer being used as the this pointer in a
USBDeviceConnected object, which caused a write to a small offset from
address 0, which caused a fault. Fixing this triggered a new bug in another
location, but the second commit in this PR fixes that one too, by adding an extra
guard clause that checks for nullptr.