### PR TITLE
Add device connected callback support

### DIFF
--- a/src/USBHost/USBHost.cpp
+++ b/src/USBHost/USBHost.cpp
@@ -30,6 +30,8 @@ USBHost * USBHost::instHost = NULL;
 
 #define MIN(a, b) ((a > b) ? b : a)
 
+extern void (*mount_fnc)(void);
+
 /**
 * How interrupts are processed:
 *    - new device connected:
@@ -184,6 +186,11 @@ void USBHost::usb_process()
                         }
 
                         USB_INFO("New device connected: %p [hub: %d - port: %d]", &devices[i], usb_msg->hub, usb_msg->port);
+
+                        // Call the device connected callback if registered
+                        if (nullptr != mount_fnc) {
+                            mount_fnc();
+                        }
 
 #if MAX_HUB_NB
                         if (buf[4] == HUB_CLASS) {

--- a/src/USBHostMSD/USBHostMSD.cpp
+++ b/src/USBHostMSD/USBHostMSD.cpp
@@ -28,6 +28,8 @@
 #define GET_MAX_LUN             (0xFE)
 #define BO_MASS_STORAGE_RESET   (0xFF)
 
+void (*mount_fnc)(void) = nullptr;
+
 USBHostMSD::USBHostMSD()
 {
     /*  register an object in FAT */
@@ -59,10 +61,10 @@ bool USBHostMSD::connected()
 
 bool USBHostMSD::connect()
 {
-
     if (dev_connected) {
         return true;
     }
+
     host = USBHost::getHostInst();
 
     for (uint8_t i = 0; i < MAX_DEVICE_CONNECTED; i++) {
@@ -90,6 +92,7 @@ bool USBHostMSD::connect()
                 host->registerDriver(dev, msd_intf, this, &USBHostMSD::init_usb);
 
                 dev_connected = true;
+
                 return true;
             }
         } //if()
@@ -430,4 +433,13 @@ const char *USBHostMSD::get_type() const
 {
     return "USBMSD";
 }
+
+// The callback will only be called if connect() has been used at least once before,
+// because of an older bugfix (commit 72d0aa6), but this is still useful - see the
+// implementation in Arduino_POSIXStorage for an example
+bool USBHostMSD::attach_detected_callback(void (*cbk)()) {
+    mount_fnc = cbk;
+    return true;
+}
+
 #endif

--- a/src/USBHostMSD/USBHostMSD.h
+++ b/src/USBHostMSD/USBHostMSD.h
@@ -64,7 +64,7 @@ public:
     virtual mbed::bd_size_t get_erase_size() const;
     virtual mbed::bd_size_t size() const;
     virtual const char *get_type() const;
-
+    bool attach_detected_callback(void (*cbk)());
 
 
 protected:


### PR DESCRIPTION
This is a port of the attach_detected_callback() functionality from the Renesas core. The only difference is that connect() must be used once first for this to work because of an older bugfix (commit 72d0aa6).