### PR TITLE
Fix within/writable spelling in `.\src\USBHost` and `.\src\USBHost3GModule`

### DIFF
--- a/src/USBHost/USBDeviceConnected.h
+++ b/src/USBHost/USBDeviceConnected.h
@@ -65,7 +65,7 @@ public:
     * @param intf_nb the interface on which to lookup the USBEndpoint
     * @param type type of the USBEndpoint looked for
     * @param dir direction of the USBEndpoint looked for
-    * @param index the index of the USBEndpoint whitin the interface
+    * @param index the index of the USBEndpoint within the interface
     * @returns pointer on the USBEndpoint if found, NULL otherwise
     */
     USBEndpoint * getEndpoint(uint8_t intf_nb, ENDPOINT_TYPE type, ENDPOINT_DIRECTION dir, uint8_t index = 0);

--- a/src/USBHost3GModule/IUSBHostSerial.h
+++ b/src/USBHost3GModule/IUSBHostSerial.h
@@ -74,7 +74,7 @@ public:
     *
     * @returns the number of bytes available
     */
-    virtual int writeable() = 0;
+    virtual int writable() = 0;
 
     /**
      *  Attach a handler to call when a packet is received / when a packet has been transmitted.
@@ -84,7 +84,7 @@ public:
     virtual void attach(IUSBHostSerialListener* pListener) = 0;
 
     /**
-     * Enable or disable readable/writeable callbacks
+     * Enable or disable readable/writable callbacks
      */
     virtual void setupIrq(bool en, IrqType irq = RxIrq) = 0;
 

--- a/src/USBHost3GModule/IUSBHostSerialListener.h
+++ b/src/USBHost3GModule/IUSBHostSerialListener.h
@@ -29,7 +29,7 @@ class IUSBHostSerialListener
 {
 public:
   virtual void readable() = 0; //Called when new data is available
-  virtual void writeable() = 0; //Called when new space is available
+  virtual void writable() = 0; //Called when new space is available
 };
 
 #endif /* USBHOST_3GMODULE */

--- a/src/USBHost3GModule/WANDongleSerialPort.cpp
+++ b/src/USBHost3GModule/WANDongleSerialPort.cpp
@@ -187,7 +187,7 @@ int WANDongleSerialPort::readable()
   return res;
 }
 
-int WANDongleSerialPort::writeable()
+int WANDongleSerialPort::writable()
 {
   tx_mtx.lock();
   if (lock_tx)
@@ -246,7 +246,7 @@ void WANDongleSerialPort::setupIrq(bool en, IrqType irq /*= RxIrq*/)
     {
       cb_tx_pending = false;
       tx_mtx.unlock();
-      listener->writeable(); //Process the interrupt that was raised
+      listener->writable(); //Process the interrupt that was raised
     }
     else
     {
@@ -321,7 +321,7 @@ void WANDongleSerialPort::txHandler()
     if(cb_tx_en)
     {
       tx_mtx.unlock();
-      listener->writeable(); //Call handler from the IRQ context
+      listener->writable(); //Call handler from the IRQ context
       //writePacket() should be called by the handler subsequently once the buffer has been filled
     }
     else

--- a/src/USBHost3GModule/WANDongleSerialPort.h
+++ b/src/USBHost3GModule/WANDongleSerialPort.h
@@ -81,7 +81,7 @@ public:
     *
     * @returns the number of bytes available
     */
-    virtual int writeable();
+    virtual int writable();
 
     /**
      *  Attach a handler to call when a packet is received / when a packet has been transmitted.
@@ -91,7 +91,7 @@ public:
     virtual void attach(IUSBHostSerialListener* pListener);
 
     /**
-     * Enable or disable readable/writeable callbacks
+     * Enable or disable readable/writable callbacks
      */
     virtual void setupIrq(bool en, IrqType irq = RxIrq);
 


### PR DESCRIPTION
The current status on the Readme page states that the Spelling Check is not passing.

![bild](https://github.com/arduino-libraries/Arduino_USBHostMbed5/assets/75624145/e52aea7f-2e00-4ba7-bc64-b7fd669e71ea)

This PR resolves issues in https://github.com/arduino-libraries/Arduino_USBHostMbed5/actions/runs/6708967539 to make sure that the spell check passes https://github.com/arduino-libraries/Arduino_USBHostMbed5/actions/runs/6723001780