### PR TITLE
Fix hang on GIGABYTE keyboard

### DIFF
--- a/src/USBHost/USBHost.cpp
+++ b/src/USBHost/USBHost.cpp
@@ -1017,6 +1017,10 @@ void USBHost::parseConfDescr(USBDeviceConnected * dev, uint8_t * conf_descr, uin
 
     while (index < len) {
         len_desc = conf_descr[index];
+        if (len_desc == 0) {
+            index++;
+            continue;
+        }
         id = conf_descr[index+1];
         switch (id) {
             case CONFIGURATION_DESCRIPTOR:


### PR DESCRIPTION
resolves #40 

0 length items in the configuration descriptor.

As I mentioned in the issue: There as some devices who have 0 length fields within their configuration descriptor
Example GIGABYTE keyboard.
```
Configuration Descriptor
2400E8F0 - 09 02 54 00 03 01 00 A0  32 09 04 00 00 01 03 01  : ..T..... 2.......
2400E900 - 01 00 09 21 10 01 00 01  22 3B 00 07 05 81 03 08  : ...!.... ";......
2400E910 - 00 08 09 04 01 00 01 03  01 22 51 00 07 05 82 03  : ........ ."Q.....
2400E920 - 10 00 08 09 04 02 00 01  03 00 00 00 09 21 10 01  : ........ .....!..
2400E930 - 00 01 22 25 00 07 05 83  03 10 00 01 00 00 00 00  : .."%.... ........
2400E940 - 00 00 00 00                                       : ....
```
The issue came up before on another USBHost library (USBHost_t36).
The solution is when you find a zero length field, you simply increment to the next byte. 

It works on my WIP branch, however here hard to test as the current released code fails to read in the full descriptors.
But that is a different issue and PR.