### PR TITLE
Fix USB Host issues

### DIFF
--- a/src/USBHost/IUSBEnumerator.h
+++ b/src/USBHost/IUSBEnumerator.h
@@ -31,6 +31,7 @@ public:
     virtual bool parseInterface(uint8_t intf_nb, uint8_t intf_class, uint8_t intf_subclass, uint8_t intf_protocol) = 0; //Must return true if the interface should be parsed
     virtual bool useEndpoint(uint8_t intf_nb, ENDPOINT_TYPE type, ENDPOINT_DIRECTION dir) = 0; //Must return true if the endpoint will be used
     virtual void parseConfigEntry(uint8_t type, uint8_t sub_type, uint8_t *data, uint32_t len) {};
+    virtual void setEnumeratingDeviceIndex(int index) {};
 };
 
 #endif /*IUSBENUMERATOR_H_*/

--- a/src/USBHost/IUSBEnumerator.h
+++ b/src/USBHost/IUSBEnumerator.h
@@ -30,6 +30,7 @@ public:
     virtual void setVidPid(uint16_t vid, uint16_t pid) = 0;
     virtual bool parseInterface(uint8_t intf_nb, uint8_t intf_class, uint8_t intf_subclass, uint8_t intf_protocol) = 0; //Must return true if the interface should be parsed
     virtual bool useEndpoint(uint8_t intf_nb, ENDPOINT_TYPE type, ENDPOINT_DIRECTION dir) = 0; //Must return true if the endpoint will be used
+    virtual void parseConfigEntry(uint8_t type, uint8_t sub_type, uint8_t *data, uint32_t len) {};
 };
 
 #endif /*IUSBENUMERATOR_H_*/

--- a/src/USBHost/USBHost.cpp
+++ b/src/USBHost/USBHost.cpp
@@ -225,6 +225,8 @@ void USBHost::usb_process()
 
                         if ((i < MAX_DEVICE_CONNECTED) && !too_many_hub) {
                             deviceInUse[i] = true;
+                            if(device_connected_callback)
+                              device_connected_callback(i);
                         }
 
                     } while(0);
@@ -960,6 +962,7 @@ USB_TYPE USBHost::enumerate(USBDeviceConnected * dev, IUSBEnumerator* pEnumerato
         dev->setPid(data[10] | (data[11] << 8));
         USB_DBG("CLASS: %02X \t VID: %04X \t PID: %04X", data[4], data[8] | (data[9] << 8), data[10] | (data[11] << 8));
 
+        pEnumerator->setEnumeratingDeviceIndex(index);
         pEnumerator->setVidPid( data[8] | (data[9] << 8), data[10] | (data[11] << 8) );
 
         res = getConfigurationDescriptor(dev, data, sizeof(data), &total_conf_descr_length);

--- a/src/USBHost/USBHost.cpp
+++ b/src/USBHost/USBHost.cpp
@@ -1066,6 +1066,8 @@ void USBHost::parseConfDescr(USBDeviceConnected * dev, uint8_t * conf_descr, uin
                 lenReportDescr = conf_descr[index + 7] | (conf_descr[index + 8] << 8);
                 break;
             default:
+                if(parsing_intf)
+                  pEnumerator->parseConfigEntry(id, conf_descr[index+2],  &conf_descr[index+3], len_desc-3);
                 break;
         }
         index += len_desc;

--- a/src/USBHost/USBHost.h
+++ b/src/USBHost/USBHost.h
@@ -189,6 +189,15 @@ public:
         }
     }
 
+
+    /**
+     * Callback for connected device index
+     */
+    void setDeviceConnectedCallback(mbed::Callback<void(uint8_t uDeviceIndex)> callback)
+    {
+      device_connected_callback = callback;
+    }
+
     /**
      * Instantiate to protect USB thread from accessing shared objects (USBConnectedDevices and Interfaces)
      */
@@ -287,6 +296,8 @@ private:
     // buffer for conf descriptor
     uint8_t data[415];
 
+    mbed::Callback<void(uint8_t uDeviceIndex)> device_connected_callback = nullptr;
+    
     /**
     * Add a transfer on the TD linked list associated to an ED
     *

--- a/src/USBHost/USBHostConf.h
+++ b/src/USBHost/USBHostConf.h
@@ -17,6 +17,8 @@
 #ifndef USBHOST_CONF_H
 #define USBHOST_CONF_H
 
+#define ARC_USB_FULL_SIZE=1
+
 #include "mbed_config.h"
 #include "Callback.h"
 #include "Arduino.h"

--- a/src/USBHost/USBHostConf.h
+++ b/src/USBHost/USBHostConf.h
@@ -17,7 +17,7 @@
 #ifndef USBHOST_CONF_H
 #define USBHOST_CONF_H
 
-#define ARC_USB_FULL_SIZE=1
+#define ARC_USB_FULL_SIZE (1)
 
 #include "mbed_config.h"
 #include "Callback.h"

--- a/src/USBHost/dbg.h
+++ b/src/USBHost/dbg.h
@@ -18,7 +18,7 @@
 #define USB_DEBUG_H
 
 //Debug is disabled by default
-#define DEBUG 0 /*INFO,ERR,WARN*/
+#define DEBUG 4 /*INFO,ERR,WARN*/
 #define DEBUG_TRANSFER 0
 #define DEBUG_EP_STATE 0
 #define DEBUG_EVENT 0

--- a/src/USBHostHub/USBHostHub.cpp
+++ b/src/USBHostHub/USBHostHub.cpp
@@ -147,7 +147,7 @@ void USBHostHub::disconnect()
     if ((hub_intf == -1) &&
             (intf_class == HUB_CLASS) &&
             (intf_subclass == 0) &&
-            (intf_protocol == 0)) {
+            ((intf_protocol == 0) || (intf_protocol == 1))) {
         hub_intf = intf_nb;
         return true;
     }

--- a/src/targets/TARGET_STM/USBEndpoint_STM.cpp
+++ b/src/targets/TARGET_STM/USBEndpoint_STM.cpp
@@ -178,7 +178,12 @@ USB_TYPE USBEndpoint::queueTransfer()
     }
     ep_queue.get(0);
     MBED_ASSERT(*addr == 0);
+#if ARC_USB_FULL_SIZE
+	transfer_len =   td_current->size;
+#else
     transfer_len =   td_current->size <= max_size ? td_current->size : max_size;
+#endif
+
     buf_start = (uint8_t *)td_current->currBufPtr;
 
     //Now add this free TD at this end of the queue

--- a/src/targets/TARGET_STM/USBHALHost_STM.cpp
+++ b/src/targets/TARGET_STM/USBHALHost_STM.cpp
@@ -118,7 +118,7 @@ void HAL_HCD_HC_NotifyURBChange_Callback(HCD_HandleTypeDef *pHcd, uint8_t uChann
       {
         case URB_NOTREADY:
         {
-          // If we have transfered any data then disable retries
+          // If we have transferred any data then disable retries
           if(pHcd->hc[uChannel].xfer_count > 0)
             pTransferDescriptor->retry = 0xffffffff; // Disable retries
           else

--- a/src/targets/TARGET_STM/USBHALHost_STM.cpp
+++ b/src/targets/TARGET_STM/USBHALHost_STM.cpp
@@ -171,7 +171,7 @@ void HAL_HCD_HC_NotifyURBChange_Callback(HCD_HandleTypeDef *pHcd, uint8_t uChann
     if (pTransferDescriptor->state == USB_TYPE_IDLE) 
     {
         // Disable retrues
-        pTransferDescriptor->retry = 0xffffffff; // Disable retries
+        pTransferDescriptor->retry = 0;
 
         // Update transfer descriptor buffer pointer
         pTransferDescriptor->currBufPtr += HAL_HCD_HC_GetXferCount(pHcd, uChannel);

--- a/src/targets/TARGET_STM/USBHALHost_STM.cpp
+++ b/src/targets/TARGET_STM/USBHALHost_STM.cpp
@@ -108,7 +108,7 @@ void HAL_HCD_HC_NotifyURBChange_Callback(HCD_HandleTypeDef *pHcd, uint8_t uChann
 
     if ((endpointType == EP_TYPE_INTR)) 
     {
-      // Disable the channel interupt and retransfer below
+      // Disable the channel interrupt and retransfer below
       pTransferDescriptor->state = USB_TYPE_IDLE ;
       HAL_HCD_DisableInt(pHcd, uChannel);
     } 
@@ -444,7 +444,7 @@ void USBHALHost::UsbIrqhandler()
 #if ARC_USB_FULL_SIZE
   // fix from Lix Paulian : https://community.st.com/t5/stm32-mcus-products/stm32f4-stm32f7-usb-host-core-interrupt-flood/td-p/436225/page/4
 
-  // Enable USB_OTG_HCINT_NAK interupts for CTRL and BULK on USB_OTG_GINTSTS_SOF (1ms)
+  // Enable USB_OTG_HCINT_NAK interrupts for CTRL and BULK on USB_OTG_GINTSTS_SOF (1ms)
   uint32_t ch_num;
   HCD_HandleTypeDef* hhcd = (HCD_HandleTypeDef *)usb_hcca;
 
@@ -459,7 +459,7 @@ void USBHALHost::UsbIrqhandler()
  
   HAL_HCD_IRQHandler((HCD_HandleTypeDef *)usb_hcca);
 
-  // Disable USB_OTG_HCINT_NAK interupts for CTRL and BULK on USB_OTG_GINTSTS_HCINT
+  // Disable USB_OTG_HCINT_NAK interrupts for CTRL and BULK on USB_OTG_GINTSTS_HCINT
   if (__HAL_HCD_GET_FLAG(hhcd, USB_OTG_GINTSTS_HCINT) && hhcd->Init.dma_enable == 0)
   {
     for (ch_num = 0; ch_num < hhcd->Init.Host_channels; ch_num++)

--- a/src/targets/TARGET_STM/USBHALHost_STM.cpp
+++ b/src/targets/TARGET_STM/USBHALHost_STM.cpp
@@ -468,7 +468,6 @@ void USBHALHost::UsbIrqhandler()
   {
     for (ch_num = 0; ch_num < hhcd->Init.Host_channels; ch_num++)
     {
-      LogicUint7(USBx_HC(ch_num)->HCINT);
       if ((hhcd->hc[ch_num].ep_type == EP_TYPE_CTRL) || (hhcd->hc[ch_num].ep_type == EP_TYPE_BULK))
       {
         if (USBx_HC(ch_num)->HCINT & USB_OTG_HCINT_NAK)

--- a/src/targets/TARGET_STM/USBHALHost_STM.cpp
+++ b/src/targets/TARGET_STM/USBHALHost_STM.cpp
@@ -123,7 +123,7 @@ void HAL_HCD_HC_NotifyURBChange_Callback(HCD_HandleTypeDef *pHcd, uint8_t uChann
             pTransferDescriptor->retry = 0xffffffff; // Disable retries
           else
           {
-            // if the retry count is 0 then initialise downward counting retry
+            // if the retry count is 0 then initialize downward counting retry
             // otherwise decrement retry count
             if(pTransferDescriptor->retry == 0)
               pTransferDescriptor->retry = uRetryCount;
@@ -134,7 +134,7 @@ void HAL_HCD_HC_NotifyURBChange_Callback(HCD_HandleTypeDef *pHcd, uint8_t uChann
           // If our retry count has got down to 0 or we are an Ack then submit request again
           if((pTransferDescriptor->retry == 0) || (pTransferDescriptor->size==0))
           {
-            //  initialise downward counting retry
+            //  initialize downward counting retry
             pTransferDescriptor->retry = uRetryCount;
 
             // resubmit the request.

--- a/src/targets/TARGET_STM/USBHALHost_STM.cpp
+++ b/src/targets/TARGET_STM/USBHALHost_STM.cpp
@@ -456,7 +456,8 @@ void USBHALHost::UsbIrqhandler()
       USBx_HC(ch_num)->HCINTMSK |= USB_OTG_HCINT_NAK;
 
       // workaround the interrupts flood issue: re-enable CHH interrupt
-      USBx_HC(ch_num)->HCINTMSK |= USB_OTG_HCINT_CHH;
+      if(hhcd->hc[ch_num].ep_type == EP_TYPE_CTRL)
+        USBx_HC(ch_num)->HCINTMSK |= USB_OTG_HCINT_CHH;
     }
   }
 
@@ -467,6 +468,7 @@ void USBHALHost::UsbIrqhandler()
   {
     for (ch_num = 0; ch_num < hhcd->Init.Host_channels; ch_num++)
     {
+      LogicUint7(USBx_HC(ch_num)->HCINT);
       if ((hhcd->hc[ch_num].ep_type == EP_TYPE_CTRL) || (hhcd->hc[ch_num].ep_type == EP_TYPE_BULK))
       {
         if (USBx_HC(ch_num)->HCINT & USB_OTG_HCINT_NAK)
@@ -475,7 +477,7 @@ void USBHALHost::UsbIrqhandler()
           USBx_HC(ch_num)->HCINTMSK &= ~USB_OTG_HCINT_NAK;
         }
 
-        if (USBx_HC(ch_num)->HCINT & USB_OTG_HCINT_CHH)
+        if ((USBx_HC(ch_num)->HCINT & USB_OTG_HCINT_CHH) && (hhcd->hc[ch_num].ep_type == EP_TYPE_CTRL))
         {
           // workaround the interrupts flood issue: disable CHH interrupt
           USBx_HC(ch_num)->HCINTMSK &= ~USB_OTG_HCINT_CHH;


### PR DESCRIPTION
Code to fix the issues currently with the USB Host code.

Enable with `ARC_USB_FULL_SIZE=1`

Use the HAL to handle the entire transfer.

Stop the NAKs flooding the cpu.

Stop the CHHs flooding the cpu.

Only retry if no data has already been received for transfer.