### PR TITLE
Add parseConfigEntry to IUSBEnumerator, call from parseConfDescr()

### DIFF
--- a/src/USBHost/IUSBEnumerator.h
+++ b/src/USBHost/IUSBEnumerator.h
@@ -30,6 +30,7 @@ public:
     virtual void setVidPid(uint16_t vid, uint16_t pid) = 0;
     virtual bool parseInterface(uint8_t intf_nb, uint8_t intf_class, uint8_t intf_subclass, uint8_t intf_protocol) = 0; //Must return true if the interface should be parsed
     virtual bool useEndpoint(uint8_t intf_nb, ENDPOINT_TYPE type, ENDPOINT_DIRECTION dir) = 0; //Must return true if the endpoint will be used
+    virtual void parseConfigEntry(uint8_t type, uint8_t sub_type, uint8_t *data, uint32_t len) {};
 };
 
 #endif /*IUSBENUMERATOR_H_*/

--- a/src/USBHost/USBHost.cpp
+++ b/src/USBHost/USBHost.cpp
@@ -1066,6 +1066,8 @@ void USBHost::parseConfDescr(USBDeviceConnected * dev, uint8_t * conf_descr, uin
                 lenReportDescr = conf_descr[index + 7] | (conf_descr[index + 8] << 8);
                 break;
             default:
+                if(parsing_intf)
+                  pEnumerator->parseConfigEntry(id, conf_descr[index+2],  &conf_descr[index+3], len_desc-3);
                 break;
         }
         index += len_desc;


### PR DESCRIPTION
Extend IUSBEnumerator to allow driver to get at configuration data whilst enumerating.