### PR TITLE
Fs over hs

### DIFF
--- a/src/USBHost/USBHostConf.h
+++ b/src/USBHost/USBHostConf.h
@@ -17,7 +17,8 @@
 #ifndef USBHOST_CONF_H
 #define USBHOST_CONF_H
 
-#define ARC_USB_FULL_SIZE (1)
+#define ARC_USB_FULL_SIZE (0)
+#define ARC_FS_OVER_HS (1)
 
 #include "mbed_config.h"
 #include "Callback.h"

--- a/src/USBHost/USBHostConf.h
+++ b/src/USBHost/USBHostConf.h
@@ -19,6 +19,7 @@
 
 #define ARC_USB_FULL_SIZE (0)
 #define ARC_FS_OVER_HS (1)
+#define ARC_NO_RESUBMITREQUEST (0)
 
 #include "mbed_config.h"
 #include "Callback.h"

--- a/src/targets/TARGET_STM/USBHALHost_STM.cpp
+++ b/src/targets/TARGET_STM/USBHALHost_STM.cpp
@@ -121,6 +121,7 @@ void HAL_HCD_HC_NotifyURBChange_Callback(HCD_HandleTypeDef *pHcd, uint8_t uChann
       // TOD: really this retransfer should be queued up and transfered on the SOF interupt based on interval from descriptor.
       pTransferDescriptor->state = USB_TYPE_IDLE ;
       HAL_HCD_DisableInt(pHcd, uChannel);
+      pTransferDescriptor->currBufPtr += HAL_HCD_HC_GetXferCount(pHcd, uChannel);
     } 
     else if ((endpointType == EP_TYPE_BULK) || (endpointType == EP_TYPE_CTRL)) 
     {


### PR DESCRIPTION
Yet another go at getting USB Host on Giga reliable.

We now have three defines in `USBUserConf.h` for testing.

`ARC_USB_FULL_SIZE` and `ARC_FS_OVER_HS` are mutually exclusive so be careful not to enable both!

`ARC_USB_FULL_SIZE=1` will run the existing code.
`ARC_FS_OVER_HS=1` will run the new code, where output transfers are split into packets and input transfers are done full size.

`ARC_NO_RESUBMITREQUEST=1` will use the HCCHAR register, which I thought would fix the NAK issue, it doesn't seem to do this in all cases. Specifically setup control data.

`ARC_NO_RESUBMITREQUEST=0` will resubmit any out packets, not fully tested with all devices.

So use:

run existing code for testing:
```
#define ARC_USB_FULL_SIZE (1)
#define ARC_FS_OVER_HS (0)
#define ARC_NO_RESUBMITREQUEST (0)
```

run new code with HCCHAR changes for testing:
```
#define ARC_USB_FULL_SIZE (0)
#define ARC_FS_OVER_HS (1)
#define ARC_NO_RESUBMITREQUEST (1)
```

run new code with retransmit for testing:
```
#define ARC_USB_FULL_SIZE (0)
#define ARC_FS_OVER_HS (1)
#define ARC_NO_RESUBMITREQUEST (0)
```

The last case is the one setup by default.