### PR TITLE
Add GIGA R1 WiFi as compatible

### DIFF
--- a/examples/DirList/DirList.ino
+++ b/examples/DirList/DirList.ino
@@ -5,7 +5,7 @@
   get a list of the existing folders and files.
 
   The circuit:
-   - Portenta H7
+   - Portenta H7 or Giga R1 WiFi
 
   This example code is in the public domain.
 */

--- a/examples/DirList/DirList.ino
+++ b/examples/DirList/DirList.ino
@@ -5,7 +5,7 @@
   get a list of the existing folders and files.
 
   The circuit:
-   - Portenta H7 or Giga R1 WiFi
+   - Portenta H7 or GIGA R1 WiFi
 
   This example code is in the public domain.
 */

--- a/examples/FileRead/FileRead.ino
+++ b/examples/FileRead/FileRead.ino
@@ -7,7 +7,7 @@
   in your storage device and write some content inside.
 
   The circuit:
-   - Portenta H7 or Giga R1 WiFi
+   - Portenta H7 or GIGA R1 WiFi
 
   This example code is in the public domain.
 */

--- a/examples/FileRead/FileRead.ino
+++ b/examples/FileRead/FileRead.ino
@@ -7,7 +7,7 @@
   in your storage device and write some content inside.
 
   The circuit:
-   - Portenta H7
+   - Portenta H7 or Giga R1 WiFi
 
   This example code is in the public domain.
 */

--- a/examples/FileWrite/FileWrite.ino
+++ b/examples/FileWrite/FileWrite.ino
@@ -5,7 +5,7 @@
   write a file, eventually overwriting the original content.
 
   The circuit:
-   - Portenta H7 or Giga R1 WiFi
+   - Portenta H7 or GIGA R1 WiFi
 
   This example code is in the public domain.
 */

--- a/examples/FileWrite/FileWrite.ino
+++ b/examples/FileWrite/FileWrite.ino
@@ -5,7 +5,7 @@
   write a file, eventually overwriting the original content.
 
   The circuit:
-   - Portenta H7
+   - Portenta H7 or Giga R1 WiFi
 
   This example code is in the public domain.
 */


### PR DESCRIPTION
This PR adds the Arduino Giga R1 WiFi as compatible board to in the comments to the following examples:
- [DirList.ino](https://github.com/arduino-libraries/Arduino_USBHostMbed5/blob/main/examples/DirList/DirList.ino)
- [FileRead.ino](https://github.com/arduino-libraries/Arduino_USBHostMbed5/blob/main/examples/FileRead/FileRead.ino)
- [FileWrite.ino](https://github.com/arduino-libraries/Arduino_USBHostMbed5/blob/main/examples/FileWrite/FileWrite.ino)



