### PR TITLE
Fix spell check false positive by ignoring word

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -2,7 +2,7 @@
 # See: https://github.com/codespell-project/codespell#using-a-config-file
 [codespell]
 # In the event of a false positive, add the problematic word, in all lowercase, to a comma-separated list here:
-ignore-words-list = freeed,unstall,
+ignore-words-list = freeed,nexted,unstall,
 skip = ./.git,./.licenses,__pycache__,node_modules,./go.mod,./go.sum,./package-lock.json,./poetry.lock,./yarn.lock
 builtin = clear,informal,en-GB_to_en-US
 check-filenames =


### PR DESCRIPTION
The [**codespell**](https://github.com/codespell-project/codespell) spellchecker tool is used to automatically detect commonly misspelled words in the files of this project.

One of the identifiers `nextED` used in the codebase happens to match against the misspelled word dictionary entry for "nested", which causes codespell to produce a false misspelled word detection:

https://github.com/arduino-libraries/Arduino_USBHostMbed5/actions/runs/15993572864/job/45111731078#step:4:17

```text
Error: ./src/USBHost/USBEndpoint.cpp:43: nextED ==> nested, texted
Error: ./src/USBHost/USBEndpoint.cpp:164: nextED ==> nested, texted
Error: ./src/USBHost/USBHost.cpp:785: nextED ==> nested, texted
Error: ./src/USBHost/USBHostTypes.h:[19](https://github.com/arduino-libraries/Arduino_USBHostMbed5/actions/runs/15993572864/job/45111731078#step:4:20)2: nextED ==> nested, texted
Codespell found one or more problems
```

Since the code that produced the detection is correct and intended, the false positive is resolved by [configuring](https://github.com/codespell-project/codespell#using-a-config-file) **codespell** to ignore the problematic word.


